### PR TITLE
Rescaling big images

### DIFF
--- a/brainboard/board.py
+++ b/brainboard/board.py
@@ -86,12 +86,14 @@ class Board(object):
         new_images = []
         for idx, image in enumerate(images):
             new_images.append(image)
-            while not True in [shape < 500 for shape in image.shape[1:]]:
+            while True not in [shape < 500 for shape in image.shape[1:]]:
                 # here we use the rescale function from scikitimage 1.80, which
                 # requires the channel dimension to be last. In next versions
-                # it will be changed by giving the index to "channel_idx" argument
+                # it will be changed by giving the index to "channel_idx"
+                # argument
                 image = image.transpose((1, 2, 0))
-                image = rescale(image,  0.5, anti_aliasing=True, multichannel=True)
+                image = rescale(
+                    image,  0.5, anti_aliasing=True, multichannel=True)
                 new_images[idx] = image.transpose((2, 0, 1))
         images = np.asarray(new_images)
         self.viewer.images(

--- a/brainboard/board.py
+++ b/brainboard/board.py
@@ -106,8 +106,8 @@ class Board(object):
         ----------
         name: str
             the name of the plot to be updated.
-        images: array (1,X,Y) or (3,X,Y)
-            the images to be displayed.
+        image: array (1,X,Y) or (3,X,Y)
+            the image to be displayed.
         title: str, default None
             the image title.
         """

--- a/brainboard/info.py
+++ b/brainboard/info.py
@@ -69,5 +69,6 @@ REQUIRES = [
     "torchinfo>=1.5.2",
     "torchviz>=0.0.2",
     "torch>=1.8.1",
-    "torchvision>=0.9.1"
+    "torchvision>=0.9.1",
+    "scikit-image>=0.18.3",
 ]


### PR DESCRIPTION
When an image is too big (both height and weight over 500 pixels), we rescale it so its has the same scale as the other plots by dividing its size by 2